### PR TITLE
Rename frontend autoEnd to autoStop

### DIFF
--- a/front/waq/src/pages/index.tsx
+++ b/front/waq/src/pages/index.tsx
@@ -59,7 +59,7 @@ const formSchema = z.object({
     )
     .optional(),
   autoStart: z.boolean().default(true),
-  autoEnd: z.boolean().default(true),
+  autoStop: z.boolean().default(true),
 })
 
 export default function StreamForm() {
@@ -81,7 +81,7 @@ export default function StreamForm() {
       description: "",
       startTime: "00:00",
       autoStart: true,
-      autoEnd: true,
+      autoStop: true,
     },
   })
 
@@ -122,7 +122,7 @@ export default function StreamForm() {
         description: values.description,
         thumbnail: thumbnailBase64,
         autoStart: values.autoStart,
-        autoEnd: values.autoEnd,
+        autoStop: values.autoStop,
       }
 
       // APIにリクエストを送信
@@ -532,7 +532,7 @@ export default function StreamForm() {
                   />
                   <FormField
                     control={form.control}
-                    name="autoEnd"
+                    name="autoStop"
                     render={({ field }) => (
                       <FormItem className="flex flex-row items-center justify-between space-y-0">
                         <div className="space-y-0.5">

--- a/front/waq/stream-form.tsx
+++ b/front/waq/stream-form.tsx
@@ -56,7 +56,7 @@ const formSchema = z.object({
     )
     .optional(),
   autoStart: z.boolean().default(true),
-  autoEnd: z.boolean().default(true),
+  autoStop: z.boolean().default(true),
 })
 
 export default function StreamForm() {
@@ -78,7 +78,7 @@ export default function StreamForm() {
       description: "",
       startTime: "00:00",
       autoStart: true,
-      autoEnd: true,
+      autoStop: true,
     },
   })
 
@@ -112,7 +112,7 @@ export default function StreamForm() {
       })
 
       formData.append("autoStart", values.autoStart.toString())
-      formData.append("autoEnd", values.autoEnd.toString())
+      formData.append("autoStop", values.autoStop.toString())
 
       await new Promise((resolve) => setTimeout(resolve, 1000))
       setStreamInfo({
@@ -494,7 +494,7 @@ export default function StreamForm() {
                   />
                   <FormField
                     control={form.control}
-                    name="autoEnd"
+                    name="autoStop"
                     render={({ field }) => (
                       <FormItem className="flex flex-row items-center justify-between space-y-0">
                         <div className="space-y-0.5">


### PR DESCRIPTION
### Motivation
- Align frontend form fields with backend JSON naming by replacing `autoEnd` with `autoStop` so the payload keys match the backend `autoStop` field.

### Description
- Replaced `autoEnd` with `autoStop` in form schema defaults and form `defaultValues` in `front/waq/src/pages/index.tsx` and `front/waq/stream-form.tsx`.
- Updated request construction to send `autoStop` instead of `autoEnd` and adjusted the form field bindings (`name=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b4c3b5548328b4caf31ae6ad71b1)